### PR TITLE
Hotkey to toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 obj/
 .vs/
+/Publish.ps1
+/CstiDetailedCardProgress.csproj.user

--- a/CstiDetailedCardProgress.csproj
+++ b/CstiDetailedCardProgress.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <AssemblyName>CstiDetailedCardProgress</AssemblyName>
     <Description>CSTI Detailed Card Progress Mod</Description>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <PackageId>space.cfan.CstiDetailedCardProgress</PackageId>
@@ -12,6 +12,7 @@
     <Copyright>MIT License</Copyright>
     <Product>CSTI Detailed Card Progress Mod</Product>
     <Company />
+	<GameAssemblyPath Condition="'$(GameAssemblyPath)' == ''">..\..\Card Survival - Tropical Island_Data\Managed</GameAssemblyPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,32 +21,32 @@
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
 	<PackageReference Include="UnityEngine.Modules" Version="2019.4.35" IncludeAssets="compile" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\Card Survival - Tropical Island_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(GameAssemblyPath)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\Card Survival - Tropical Island_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>$(GameAssemblyPath)\Unity.TextMeshPro.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\Card Survival - Tropical Island_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(GameAssemblyPath)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\Card Survival - Tropical Island_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>$(GameAssemblyPath)\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\Card Survival - Tropical Island_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(GameAssemblyPath)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\Card Survival - Tropical Island_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(GameAssemblyPath)\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\Card Survival - Tropical Island_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(GameAssemblyPath)\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This mod shows card status and progress related details in tooltip.
 ![Preview](pic/screenshot1.png)
 
 # Usage
-
-## Settings
+## Settings (Optional)
 
 The configuration file can be found at /BepInEx/config/CstiDetailedCardProgress.cfg
 
@@ -14,6 +13,8 @@ The configuration file can be found at /BepInEx/config/CstiDetailedCardProgress.
 |--|--|--|
 |Enabled|true|If set to true, will show the details tooltips|
 |HotKey|F2|The key to enable and disable the tool tips|
+
+__Toggle Note__: When using the hotkey to enable/disable the detailed tooltips, the tooltips will not be updated until the user moves the mouse off of a card.
 
 ## Install BepInEx
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ This mod shows card status and progress related details in tooltip.
 ![Preview](pic/screenshot1.png)
 
 # Usage
+
+## Settings
+
+The configuration file can be found at /BepInEx/config/CstiDetailedCardProgress.cfg
+
+|Name|Default|Description|
+|--|--|--|
+|Enabled|true|If set to true, will show the details tooltips|
+|HotKey|F2|The key to enable and disable the tool tips|
+
 ## Install BepInEx
 
 This mod works as a plug-in of BepInEx 5 framework.
@@ -21,3 +31,6 @@ See <https://docs.bepinex.dev/v5.4.21/articles/user_guide/installation/index.htm
 
 ## 1.0.2
 - Now it shows detailed weight of items and stats of character.
+
+## 1.0.3 
+- Adds enable/disable hotkey.

--- a/Stat.cs
+++ b/Stat.cs
@@ -2,16 +2,26 @@
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using static CstiDetailedCardProgress.Utils;
 
 namespace CstiDetailedCardProgress
 {
     class Stat
     {
+
         [HarmonyPostfix, HarmonyPatch(typeof(StatStatusGraphics), "Update")]
-        public static void StatStatusGraphicsPatch(StatStatusGraphics __instance)
+        public static void StatStatusGraphicsPatch(StatStatusGraphics __instance, TooltipText ___MyTooltip)
         {
-            __instance.SetTooltip(__instance.Title, $"{(string.IsNullOrWhiteSpace(__instance.ModelStatus.Description) ? "" : $"{__instance.ModelStatus.Description}\n")}{FormatInGameStat(__instance.ModelStatus.ParentStat)}", "");
+            if (Plugin.Enabled)
+            {
+                __instance.SetTooltip(__instance.Title, $"{(string.IsNullOrWhiteSpace(__instance.ModelStatus.Description) ? "" : $"{__instance.ModelStatus.Description}\n")}{FormatInGameStat(__instance.ModelStatus.ParentStat)}", "");
+            }
+            else
+            {
+                //Reset the tool tip to the base game settings.
+                __instance.SetTooltip(__instance.ModelStatus.GameName, __instance.ModelStatus.Description, "");
+            }
         }
         public static string FormatInGameStat(InGameStat stat)
         {


### PR DESCRIPTION
Adds a hotkey to toggle the detailed tooltips.  By default, the detailed tooltips are on and the hotkey is F2.  Will not affect existing users or new installs.

The Detailed Card Progress is a fantastic mod.  I wanted to only know about one thing that I was curious about and wanted to discover the rest of the mechanics myself.  Currently the only way to do this is to exit the game, disable the mod, run the game, check the result, and then undo that process.

This will not affect existing installs.

From the change log:
- Adds a hotkey to enable/disable the enhanced tooltips.
- By default the tool tips are enabled and the hotkey is F2.

.gitignore
- Modified to ignore Publish.ps1 for local file publishing.
- Ignores VS .user configurations.


CstiDetailedCardProgress.csproj
- Uses an optional GameAssemblyPath variable to allow machine
specific install directories.

Settings table formatted for NexusMods:

```
[font=Courier New] 
| Name    | Default | Description                                    |
| ------- | ------- | ---------------------------------------------- |
| Enabled | true    | If set to true, will show the details tooltips |
|         |         |                                                |
| HotKey  | F2      | The key to enable and disable the tool tips    |
[/font]
```
